### PR TITLE
Fix getElapsedSeconds handling of zero start time

### DIFF
--- a/__tests__/timeUtils.test.ts
+++ b/__tests__/timeUtils.test.ts
@@ -67,6 +67,12 @@ describe("timeUtils", () => {
       expect(getElapsedSeconds(null)).toBe(0);
     });
 
+    test("handles start time of zero", () => {
+      const mockNow = 5000;
+      Date.now = jest.fn(() => mockNow);
+      expect(getElapsedSeconds(0)).toBe(5);
+    });
+
     test("returns negative for future start time", () => {
       const mockNow = 1670000000000;
       Date.now = jest.fn(() => mockNow);

--- a/src/client/utils/timeUtils.ts
+++ b/src/client/utils/timeUtils.ts
@@ -46,7 +46,7 @@ export function parseTimecodeToSeconds(timecode: string): number {
  * @returns Elapsed seconds, or 0 if startTime is null.
  */
 export function getElapsedSeconds(startTime: number | null): number {
-  if (!startTime) {
+  if (startTime === null) {
     return 0;
   }
   return Math.floor((Date.now() - startTime) / 1000);


### PR DESCRIPTION
## Summary
- handle a `startTime` of `0` in `getElapsedSeconds`
- add unit test for this case

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c257bd984832582c20aa1aecedca4