### PR TITLE
Add reset total button for OBS mode

### DIFF
--- a/src/client/App.css
+++ b/src/client/App.css
@@ -1056,6 +1056,33 @@ body, html {
   cursor: default; /* Not clickable */
 }
 
+/* Container for total time and reset icon */
+.total-time-container {
+  display: flex;
+  align-items: center;
+  gap: 0.3em;
+}
+
+/* Small reset icon for total time */
+.reset-total-button {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 0.8em;
+  width: 1.4em;
+  height: 1.4em;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.reset-total-button:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.8);
+}
+
 /* Icons */
 .status-icon { font-size: 1em; /* Inherits size from parent (.timer-icon) */ opacity: 0.8; }
 .status-icon.recording { color: var(--color-running); }

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -173,6 +173,7 @@ function App() {
           statusMessage={statusMessage}
           statusType={statusType}
           isDimmed={isDimmed}
+          onResetTotal={resetTotalTime}
         />
       ),
       stopwatch: (

--- a/src/client/components/OBSMode.tsx
+++ b/src/client/components/OBSMode.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import {BiReset} from "react-icons/bi";
 import ConnectionStatus from "./ConnectionStatus";
 import ThreeColumnLayout from "./ThreeColumnLayout";
 
@@ -10,6 +11,7 @@ interface OBSModeProps {
   statusMessage: string;
   statusType: "connecting" | "connected" | "disconnected" | "error" | "hidden";
   isDimmed: boolean;
+  onResetTotal: () => void;
 }
 
 const OBSMode: React.FC<OBSModeProps> = ({
@@ -20,6 +22,7 @@ const OBSMode: React.FC<OBSModeProps> = ({
   statusMessage,
   statusType,
   isDimmed,
+  onResetTotal,
 }) => {
   return (
     <div className={`timer-container ${isDimmed ? "dimmed" : ""}`}>
@@ -38,7 +41,16 @@ const OBSMode: React.FC<OBSModeProps> = ({
             <div className={`time-text ${currentStatusIconClass}`}>
               {formattedCurrentTime}
             </div>
-            <div className="time-text total-time">{formattedTotalTime}</div>
+            <div className="total-time-container">
+              <div className="time-text total-time">{formattedTotalTime}</div>
+              <button
+                onClick={onResetTotal}
+                className="reset-total-button"
+                title="Reset Total Time"
+              >
+                <BiReset />
+              </button>
+            </div>
           </>
         }
         right={null /* No action button for this mode */}


### PR DESCRIPTION
## Summary
- allow resetting total recording time directly in OBS mode
- wire `resetTotalTime` into `OBSMode`
- style new reset icon

## Testing
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_684c2e3e8f3083258bfb4f34fb6f7229